### PR TITLE
Fixes tests and vet in go1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.6
+  - 1.7
 
 os:
   - linux

--- a/monitor/checks.go
+++ b/monitor/checks.go
@@ -286,12 +286,12 @@ func (c *check) SetMonitored(monitored bool) {
 func newCheck(id string, kind string) interface {
 	Checkable
 } {
-	check := check{Timeout: 120 * time.Second, ID: id, logger: log.DummyLogger()}
+	check := &check{Timeout: 120 * time.Second, ID: id, logger: log.DummyLogger()}
 	switch kind {
 	case "process":
 		return &ProcessCheck{check: check}
 	default:
-		return &check
+		return check
 	}
 }
 
@@ -549,7 +549,7 @@ func (c *ProcessCheck) Status() (str string) {
 
 // ProcessCheck defines a service type check
 type ProcessCheck struct {
-	check
+	*check
 	Group         string
 	PidFile       string
 	StartProgram  *Command

--- a/monitor/checks_test.go
+++ b/monitor/checks_test.go
@@ -32,7 +32,7 @@ func (ds *dummyService) setTimesStarted(t int) {
 }
 
 func newDummyService(id string) *dummyService {
-	s := dummyService{ProcessCheck: ProcessCheck{check: check{ID: id}}}
+	s := dummyService{ProcessCheck: ProcessCheck{check: &check{ID: id}}}
 	s.startTime = 5 * time.Millisecond
 	s.stopTime = 5 * time.Millisecond
 	s.doError = false
@@ -134,14 +134,12 @@ func (dc *dummyCheck) setTimesCalled(t int) {
 }
 
 func newDummyCheck(id string) *dummyCheck {
-	c := &dummyCheck{}
-	c.ID = id
-	return c
+	return &dummyCheck{ProcessCheck: ProcessCheck{check: &check{ID: id}}}
 }
 
 func TestCheckOnceOneSimultaneousInvocationPerObject(t *testing.T) {
 	t.Parallel()
-	dc := &dummyCheck{}
+	dc := newDummyCheck("dummy")
 	dc.Initialize(Opts{})
 
 	dc.setWaitTime(20 * time.Millisecond)
@@ -165,11 +163,11 @@ func TestCheckOnceOneSimultaneousInvocationPerObject(t *testing.T) {
 
 func TestCheckOnceTwoChecksWithSameId(t *testing.T) {
 	t.Parallel()
-	dc1 := &dummyCheck{}
+	dc1 := newDummyCheck("dummy")
 	dc1.Initialize(Opts{})
 	dc1.setWaitTime(20 * time.Millisecond)
 
-	dc2 := &dummyCheck{}
+	dc2 := newDummyCheck("dummy")
 	dc2.Initialize(Opts{})
 	dc2.setWaitTime(20 * time.Millisecond)
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -130,7 +130,7 @@ func TestUpdateDatabase(t *testing.T) {
 	db := app.database
 	assert.Len(t, db.Keys(), 0)
 	for _, id := range ids {
-		app.AddCheck(&ProcessCheck{check: check{ID: id}})
+		app.AddCheck(&ProcessCheck{check: &check{ID: id}})
 	}
 	db.Deserialize()
 	assert.Len(t, db.Keys(), 0)
@@ -143,7 +143,7 @@ func TestUpdateDatabase(t *testing.T) {
 
 	// Deregisters unknown checks
 	app.checks = nil
-	app.AddCheck(&ProcessCheck{check: check{ID: "foo"}})
+	app.AddCheck(&ProcessCheck{check: &check{ID: "foo"}})
 	app.UpdateDatabase()
 	db.Deserialize()
 	assert.Equal(t, db.Keys(), []string{"foo"})
@@ -157,7 +157,7 @@ func TestFindCheck(t *testing.T) {
 		Checkable
 	})
 	for _, id := range ids {
-		ch := &ProcessCheck{check: check{ID: id}}
+		ch := &ProcessCheck{check: &check{ID: id}}
 		checks[id] = ch
 		app.AddCheck(ch)
 	}
@@ -176,7 +176,7 @@ func TestAddCheck(t *testing.T) {
 	require.NoError(t, err)
 	logger := app.logger
 	for _, id := range ids {
-		ch := &ProcessCheck{check: check{ID: id}}
+		ch := &ProcessCheck{check: &check{ID: id}}
 		assert.NoError(t, app.AddCheck(ch))
 		// When adding the check, the app set it up to use its logger
 		// TODO: Maybe this should not be the case, so a check can be registered
@@ -185,7 +185,7 @@ func TestAddCheck(t *testing.T) {
 	}
 
 	for _, id := range ids {
-		ch := &ProcessCheck{check: check{ID: id}}
+		ch := &ProcessCheck{check: &check{ID: id}}
 		tu.AssertErrorMatch(t, app.AddCheck(ch), regexp.MustCompile("Service name conflict,.*already defined"))
 	}
 }
@@ -603,8 +603,7 @@ func TestSummaryText(t *testing.T) {
 	app, err := New(Config{})
 	require.NoError(t, err)
 	// With no checks
-	assert.Regexp(t, regexp.MustCompile("^\\s*Uptime 0\\s*$"), app.SummaryText())
-
+	assert.Regexp(t, regexp.MustCompile("^\\s*Uptime 0s?\\s*$"), app.SummaryText())
 	dc1 := newDummyCheck("dummy1")
 	// Make it to be running
 	f, _ := sb.Write(sb.TempFile(), fmt.Sprintf("%d", syscall.Getpid()))
@@ -616,7 +615,7 @@ func TestSummaryText(t *testing.T) {
 	app.AddCheck(dc2)
 
 	assert.Regexp(t, regexp.MustCompile(
-		"^\\s*Uptime 0\\s*\n\nProcess\\s+dummy1\\s+Running\nProcess\\s+dummy2\\s+Stopped\n$",
+		"^\\s*Uptime 0s?\\s*\n\nProcess\\s+dummy1\\s+Running\nProcess\\s+dummy2\\s+Stopped\n$",
 	), app.SummaryText())
 }
 
@@ -643,12 +642,12 @@ func TestStatusText(t *testing.T) {
 		statusTextHeaderPattern+`\s*Process\s+'dummy1'\s*
 \s*status\s+Running
 \s*pid\s*\d+
-\s*uptime\s*\d+
+\s*uptime\s*\d+s?
 \s*monitoring status\s*monitored
 
 Process\s+'dummy2'\s*
 \s*status\s+Stopped
-\s*uptime\s*0
+\s*uptime\s*0s?
 \s*monitoring status\s*monitored
 `,
 	), app.StatusText())


### PR DESCRIPTION
This fixes the `go vet` false positive: https://github.com/bitnami/gonit/issues/10 (golang/go#16227)

As well of other minor changes in time string representation:

https://github.com/golang/go/commit/9c4295b574a89bf02294111f811f90ab06b9951b
