### PR TITLE
Bump version

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bitnami/gonit/cmd"
 )
 
-var version = "0.2.0"
+var version = "0.2.2"
 var buildDate = ""
 var commit = ""
 


### PR DESCRIPTION
Version 0.2.1 was released without changing this value. After changing this, I will create a new release that fixes the discordance.