### PR TITLE
Gonit should set a different PPID for processes started by it

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bitnami/gonit/cmd"
 )
 
-var version = "0.2.3"
+var version = "0.2.4"
 var buildDate = ""
 var commit = ""
 

--- a/monitor/checks.go
+++ b/monitor/checks.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/bitnami/gonit/log"
@@ -334,7 +335,10 @@ func newCommand(cmdStr string, timeout time.Duration, opts Opts) *Command {
 func (c *Command) Exec() {
 	// TODO REPORT error, track std streams
 	c.logger.Debugf("/bin/bash -c %s", c.Cmd)
-	c.logger.Debug(exec.Command("/bin/bash", "-c", c.Cmd).Run())
+
+	cmd := exec.Command("/bin/bash", "-c", c.Cmd)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	c.logger.Debug(cmd.Run())
 }
 
 func formatColumns(len int, args ...interface{}) string {


### PR DESCRIPTION
We are finding issues with Apache and the way it is stopped. It looks like Apache is sending a kill signal to all parent processes, including Gonit, which is then shutdown with all that it implies:

* Gonit is not managing processes anymore.
* Gonit commands (`start`, `status`...) don't work until you manually start the daemon (`sudo gonit`) or restart.

This PR fixes that issue by making the PPID of new processes launched by Gonit different than that of the Gonit process itself.