### PR TITLE
Fix linter error SCC-SA1006

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -160,15 +161,15 @@ func getChecksManager() interface {
 	}
 	return manager
 }
-func flattenErrors(errors []error) error {
-	if len(errors) == 0 {
+func flattenErrors(errList []error) error {
+	if len(errList) == 0 {
 		return nil
 	}
 	msgs := []string{}
-	for _, err := range errors {
+	for _, err := range errList {
 		msgs = append(msgs, err.Error())
 	}
-	return fmt.Errorf(strings.Join(msgs, "\n"))
+	return errors.New(strings.Join(msgs, "\n"))
 }
 
 type serviceCommand struct {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bitnami/gonit/cmd"
 )
 
-var version = "0.2.10"
+var version = "0.2.11"
 var buildDate = ""
 var commit = ""
 


### PR DESCRIPTION
### Description of the change

Fix linter error SCC-SA1006

### Benefits

Fix `make lint` command.

### Possible drawbacks

N/A

### Applicable issues

https://jira.eng.vmware.com/browse/TAC-1652

### Additional information

https://staticcheck.dev/docs/checks#SA1006