### PR TITLE
Configure permissions for the release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,8 @@ jobs:
     needs: [ 'build-and-test' ]
     if: github.repository == 'bitnami/gonit' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093


### PR DESCRIPTION
Release job fails with this error 

```
Creating new release v0.2.12
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/bitnami/gonit/releases)
Error: Process completed with exit code 1.
```