### PR TITLE
feat: Bump Go version to 1.25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '^1.24.4' # The Go version to download (if necessary) and use.
+          go-version: '^1.25' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
         run: make get-build-deps
       - name: Download required modules

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami/gonit
 
-go 1.24
+go 1.25
 
 require (
 	github.com/VividCortex/godaemon v1.0.0


### PR DESCRIPTION
### Description of the change

Bump Go version to `1.25`.

### Benefits

Keep the project updated.

### Possible drawbacks

None
